### PR TITLE
Opinionated cleanup

### DIFF
--- a/src/os/unix/wayland.rs
+++ b/src/os/unix/wayland.rs
@@ -485,8 +485,7 @@ pub struct Window {
     mouse_y: f32,
     scroll_x: f32,
     scroll_y: f32,
-    // TODO: Was there a reason this was u8?
-    buttons: [bool; 8], // changed length to 8 in order to support future additions (Linux kernel defines 8 mouse buttons)
+    buttons: [bool; 8], // Linux kernel defines 8 mouse buttons
     prev_cursor: CursorStyle,
 
     should_close: bool,

--- a/src/os/unix/wayland.rs
+++ b/src/os/unix/wayland.rs
@@ -691,7 +691,6 @@ impl Window {
     }
 
     pub fn get_unix_menus(&self) -> Option<&Vec<UnixMenu>> {
-        // TODO: Why is this an option if it's always Some? Just unimplemented?
         Some(&self.menus)
     }
 
@@ -700,7 +699,6 @@ impl Window {
     }
 
     pub fn is_menu_pressed(&mut self) -> Option<usize> {
-        // TODO: Why is this None? Just unimplemented?
         None
     }
 

--- a/src/os/unix/wayland.rs
+++ b/src/os/unix/wayland.rs
@@ -130,20 +130,19 @@ impl BufferPool {
             size.0 * mem::size_of::<u32>() as i32,
             format,
         );
-        // TODO: is this name still accurate? Is the buffer discarded when it is no longer needed?
-        // "buf_not_needed" is too verbose with not enough information, IMO
-        let discard_buf = Rc::new(RefCell::new(false));
-        let discard_buf_clone = discard_buf.clone();
+        //Whether or not the buffer has been released by the compositor
+        let buf_released = Rc::new(RefCell::new(false));
+        let buf_released_clone = buf_released.clone();
 
         buf.quick_assign(move |_, event, _| {
             use wayland_client::protocol::wl_buffer::Event;
 
             if let Event::Release = event {
-                *discard_buf_clone.borrow_mut() = true;
+                *buf_released_clone.borrow_mut() = true;
             }
         });
 
-        (buf, discard_buf)
+        (buf, buf_released)
     }
 
     fn get_buffer(&mut self, size: (i32, i32)) -> (File, &Main<WlBuffer>) {

--- a/src/os/unix/wayland.rs
+++ b/src/os/unix/wayland.rs
@@ -196,16 +196,14 @@ impl BufferPool {
 }
 
 struct DisplayInfo {
-    // TODO: If these are never read, why are they necessary in the struct in the first place?
     attached_display: Attached<WlDisplay>,
-    _compositor: Main<WlCompositor>,
-    _base: Main<XdgWmBase>,
+    //_compositor: Main<WlCompositor>,
+    //_base: Main<XdgWmBase>,
     surface: Main<WlSurface>,
     xdg_surface: Main<XdgSurface>,
     toplevel: Main<XdgToplevel>,
-    _shm: Main<WlShm>,
     event_queue: EventQueue,
-    _seat: Main<WlSeat>,
+    //_seat: Main<WlSeat>,
     xdg_config: Rc<RefCell<Option<u32>>>,
     cursor: wayland_cursor::CursorTheme,
     cursor_surface: Main<WlSurface>,
@@ -343,14 +341,13 @@ impl DisplayInfo {
             Self {
                 _display: display,
                 attached_display,
-                _compositor: compositor,
-                _base: xdg_wm_base,
+                //_compositor: compositor,
+                //_base: xdg_wm_base,
                 surface,
                 xdg_surface,
                 toplevel: xdg_toplevel,
-                _shm: shm,
                 event_queue,
-                _seat: seat,
+                //_seat: seat,
                 xdg_config,
                 cursor,
                 cursor_surface,

--- a/src/os/unix/wayland.rs
+++ b/src/os/unix/wayland.rs
@@ -690,7 +690,6 @@ impl Window {
     }
 
     pub fn get_unix_menus(&self) -> Option<&Vec<UnixMenu>> {
-        Some(&self.menus)
         //FIXME
         unimplemented!()
     }
@@ -700,7 +699,6 @@ impl Window {
     }
 
     pub fn is_menu_pressed(&mut self) -> Option<usize> {
-        None
         //FIXME
         unimplemented!()
     }

--- a/src/os/unix/wayland.rs
+++ b/src/os/unix/wayland.rs
@@ -130,7 +130,8 @@ impl BufferPool {
             size.0 * mem::size_of::<u32>() as i32,
             format,
         );
-        //Whether or not the buffer has been released by the compositor
+
+        // Whether or not the buffer has been released by the compositor
         let buf_released = Rc::new(RefCell::new(false));
         let buf_released_clone = buf_released.clone();
 

--- a/src/os/unix/wayland.rs
+++ b/src/os/unix/wayland.rs
@@ -691,6 +691,8 @@ impl Window {
 
     pub fn get_unix_menus(&self) -> Option<&Vec<UnixMenu>> {
         Some(&self.menus)
+        //FIXME
+        unimplemented!()
     }
 
     pub fn remove_menu(&mut self, handle: MenuHandle) {
@@ -699,6 +701,8 @@ impl Window {
 
     pub fn is_menu_pressed(&mut self) -> Option<usize> {
         None
+        //FIXME
+        unimplemented!()
     }
 
     pub fn update(&mut self) {

--- a/src/os/unix/wayland.rs
+++ b/src/os/unix/wayland.rs
@@ -197,13 +197,10 @@ impl BufferPool {
 
 struct DisplayInfo {
     attached_display: Attached<WlDisplay>,
-    //_compositor: Main<WlCompositor>,
-    //_base: Main<XdgWmBase>,
     surface: Main<WlSurface>,
     xdg_surface: Main<XdgSurface>,
     toplevel: Main<XdgToplevel>,
     event_queue: EventQueue,
-    //_seat: Main<WlSeat>,
     xdg_config: Rc<RefCell<Option<u32>>>,
     cursor: wayland_cursor::CursorTheme,
     cursor_surface: Main<WlSurface>,
@@ -341,13 +338,10 @@ impl DisplayInfo {
             Self {
                 _display: display,
                 attached_display,
-                //_compositor: compositor,
-                //_base: xdg_wm_base,
                 surface,
                 xdg_surface,
                 toplevel: xdg_toplevel,
                 event_queue,
-                //_seat: seat,
                 xdg_config,
                 cursor,
                 cursor_surface,


### PR DESCRIPTION
As the title suggests, I did a bit of opinionated cleanup, in addition to fixing some things I thought needed to be fixed. This includes removing some unnecessary comments, renaming variables to make such comments unnecessary, etc. If you don't like any of the changes, leave a comment and I'll try to explain why I made that specific change.

This will need a little bit of cleaning up before you merge it into your branch (I littered a few `TODO`s and comments).

Most of my questions can be found at the `TODO` markers.

----

The first and foremost question I'd like answered is: can we better handle errors in order to avoid unwrapping? Unwrap panics are not fun to deal with/debug (even though 1.42.0 now shows where the unwrap actually happened).

(cc: @nifker -- just to ensure you see this)